### PR TITLE
fix: connect wallet on make oracle request page

### DIFF
--- a/src/components/page/oracle-script/OracleScriptExecute.res
+++ b/src/components/page/oracle-script/OracleScriptExecute.res
@@ -332,9 +332,12 @@ module ExecutionPart = {
 
     let (accountOpt, dispatch) = React.useContext(AccountContext.context)
     let trackingSub = TrackingSub.use()
-    let (_, setAccountBoxState, _, _) = React.useContext(WalletPopupContext.context)
+    let (accountBoxState, setAccountBoxState, _, _) = React.useContext(WalletPopupContext.context)
 
-    let connect = () => setAccountBoxState(_ => "noShow")
+    let connect = () =>
+      accountBoxState == "noShow"
+        ? setAccountBoxState(_ => "connect")
+        : setAccountBoxState(_ => "noShow")
     let numParams = paramsInput->Belt.Array.length
 
     let validatorCount = ValidatorSub.countByActive(true)

--- a/src/components/page/validator/ValidatorStakingInfo.res
+++ b/src/components/page/validator/ValidatorStakingInfo.res
@@ -252,9 +252,12 @@ let make = (~validatorAddress) => {
   let trackingSub = TrackingSub.use()
   let (accountOpt, _) = React.useContext(AccountContext.context)
   let ({ThemeContext.theme: theme, isDarkMode}, _) = React.useContext(ThemeContext.context)
-  let (_, setAccountBoxState, _, _) = React.useContext(WalletPopupContext.context)
+  let (accountBoxState, setAccountBoxState, _, _) = React.useContext(WalletPopupContext.context)
 
-  let connect = () => setAccountBoxState(_ => "noShow")
+  let connect = () =>
+    accountBoxState == "noShow"
+      ? setAccountBoxState(_ => "connect")
+      : setAccountBoxState(_ => "noShow")
 
   <InfoContainer>
     <div className={CssHelper.flexBox(~justify=#spaceBetween, ())}>

--- a/src/components/wallet/AccountBox.res
+++ b/src/components/wallet/AccountBox.res
@@ -95,7 +95,7 @@ module FaucetBtn = {
       switch trackingSub {
       | Data({chainID}) => {
           let currentChainID = chainID->ChainIDBadge.parseChainID
-          currentChainID == LaoziTestnet
+          currentChainID != LaoziMainnet
             ? isRequest
                 ? <LoadingCensorBar.CircleSpin size=30 height=30 />
                 : isFailed

--- a/src/components/wallet/SelectWallet.res
+++ b/src/components/wallet/SelectWallet.res
@@ -107,7 +107,7 @@ let make = () => {
         <VSpacing size=Spacing.md />
         {
           let currentChainID = chainID->ChainIDBadge.parseChainID
-          currentChainID == LaoziTestnet
+          currentChainID != LaoziMainnet
             ? <>
                 <WalletButton onClick={_ => connectMnemonic()} wallet=Wallet.Mnemonic />
                 <VSpacing size=Spacing.md />


### PR DESCRIPTION
### Related Issue: -
### What is the feature?
- on oracle-script execute page connect button doesn't work, when clicking on it nothing happen.
- want to connect via Mnemonic not only Testnet

### What is the solution?

- on connect function change  ```accountBoxState == "noShow"``` to 
       ``` accountBoxState == "noShow"
        ? setAccountBoxState(_ => "connect")
        : setAccountBoxState(_ => "noShow") ``` this will make connect wallet popup appear
- change condition when render Mnemonic from `currentChainID == LaoziTestnet` to `currentChainID != LaoziMainnet`. this make Mnemonic support on any network but mainnet


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

### How to test?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
got to http://localhost:8000/oracle-script/445#execute then click connect

### Screenshots (if any)

## Other Notes

<!-- Add any additional information that would be useful to the developer or QA tester-->
